### PR TITLE
allow custom steps return generic value

### DIFF
--- a/corounit-allure/src/main/kotlin/ru/fix/corounit/allure/Allure.kt
+++ b/corounit-allure/src/main/kotlin/ru/fix/corounit/allure/Allure.kt
@@ -12,7 +12,7 @@ inline fun <reified T: Any> createStepClassInstance(vararg args: Any?): T =
 fun <T: Any> createStepClassInstance(clazz: KClass<T>, vararg args: Any?): T =
         AllureAspect.newAspectedInstanceViaSubtyping(clazz, *args)
 
-suspend operator fun String.invoke(stepBody: suspend CoroutineScope.()->Unit) {
+suspend operator fun <T> String.invoke(stepBody: suspend CoroutineScope.()->T) {
     AllureStep.fromCurrentCoroutineContext().step(this, stepBody)
 }
 


### PR DESCRIPTION
step methods can return value, then why "some step" { can't return T? }