### PR TITLE
allow limiting number of concurrent runs

### DIFF
--- a/corounit-engine/src/main/kotlin/ru/fix/corounit/engine/Configuration.kt
+++ b/corounit-engine/src/main/kotlin/ru/fix/corounit/engine/Configuration.kt
@@ -5,6 +5,15 @@ import org.junit.platform.engine.ConfigurationParameters
 import java.util.concurrent.ForkJoinPool
 
 class Configuration(configurationParameters: ConfigurationParameters) {
+
+    val concurrentTestClassesLimit = configurationParameters.get("corounit.execution.concurrent.test.classes.limit")
+        .map { it?.toInt() }
+        .orElse(null)
+
+    val concurrentTestMethodsLimit = configurationParameters.get("corounit.execution.concurrent.test.methods.limit")
+        .map { it?.toInt() }
+        .orElse(null)
+
     val parallelism = configurationParameters.get("corounit.execution.parallelism")
             .map { it?.toInt() }
             .orElse(Math.max(ForkJoinPool.getCommonPoolParallelism(), 2))!!

--- a/corounit-engine/src/main/kotlin/ru/fix/corounit/engine/ExecutionRunner.kt
+++ b/corounit-engine/src/main/kotlin/ru/fix/corounit/engine/ExecutionRunner.kt
@@ -1,16 +1,29 @@
 package ru.fix.corounit.engine
 
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 class ExecutionRunner(private val context: ExecutionContext) {
+
+    private val classesRunsSemaphore = context.configuration.concurrentTestClassesLimit?.let { Semaphore(it) }
+    private val methodsRunsSemaphore = context.configuration.concurrentTestMethodsLimit?.let { Semaphore(it) }
 
     suspend fun executeExecution(execDesc: CorounitExecutionDescriptor) {
         context.notifyListenerAndRunInSupervisorScope(execDesc) {
             for (classDesc in execDesc.children.mapNotNull { it as? CorounitClassDescriptior }) {
                 launch {
-                    ClassRunner(context, classDesc).executeClass()
+                    classesRunsSemaphore.withPermitIfNotNull {
+                        ClassRunner(context, classDesc).executeClass(methodsRunsSemaphore)
+                    }
                 }
             }
         }
     }
+}
+
+suspend fun Semaphore?.withPermitIfNotNull(block: suspend () -> Unit) = if(this != null) {
+    withPermit { block() }
+} else {
+    block()
 }

--- a/corounit-engine/src/test/resources/junit-platform.properties
+++ b/corounit-engine/src/test/resources/junit-platform.properties
@@ -1,3 +1,5 @@
+corounit.execution.concurrent.test.classes.limit=5
+corounit.execution.concurrent.test.methods.limit=10
 corounit.execution.parallelism=2
 # Corounit engine tests share single CorounitConfig class to assert interaction with engine plugins
 # In order to ensure that one test do not affect another we are running them sequentially

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,8 @@ You can use default `junit-platform.properties` file in test resources to specif
       
 ```properties
 # junit-platform.properties
+corounit.execution.concurrent.test.classes.limit=5
+corounit.execution.concurrent.test.methods.limit=10
 corounit.execution.parallelism=4
 corounit.testinstance.lifecycle.default=per_class
 ```
@@ -376,6 +378,10 @@ class TestClass{
 ## Corounit Properties
 You can add corounit properties within default JUnit property file at `src/test/resources/junit-platform.properties`:
 
+* `corounit.execution.concurrent.test.classes.limit=null`
+ Max number of running concurrently test classes
+* `corounit.execution.concurrent.test.methods.limit=null`
+ Max number of running concurrently test methods
 * `corounit.execution.parallelism=4` 
  How many threads corounite engine will use to execute tests.
 * `corounit.testinstance.lifecycle.default=per_class` 


### PR DESCRIPTION
Running all test classes and methods at once consumes a lot of CPU/RAM/network, that might cause problems on weak machines with large amount of tests

We need both semaphores I added because
1. classRunsSemaphore doesn't limit method runs (there may be a lot of test methods within single test class)
2. methodsRunsSemaphore doesn't limit beforeAll and afterAll methods which can consume resources as well
